### PR TITLE
Fix branch name in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     rev: v5.0.0
     hooks:
       - id: no-commit-to-branch
-        args: ['--branch', 'mainx']
+        args: ['--branch', 'main']
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-yaml


### PR DESCRIPTION
Corrected the branch name from 'mainx' to 'main' in the no-commit-to-branch hook configuration. This ensures the hook properly prevents direct commits to the intended branch.

## Summary by Sourcery

CI:
- Prevent direct commits to the `main` branch.