### PR TITLE
Run tests on main and mark v1.0.0 stable

### DIFF
--- a/.github/workflows/python-test-and-build.yml
+++ b/.github/workflows/python-test-and-build.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Test and Build
         uses: ./.github/actions/test-and-build

--- a/.github/workflows/python-test-and-build.yml
+++ b/.github/workflows/python-test-and-build.yml
@@ -1,9 +1,13 @@
 name: Test and Build CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -20,6 +24,7 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Test and Build
         uses: ./.github/actions/test-and-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.0.0
+## v1.0.0 - 2026-08-24
 
 - Support Django `run_after` deferred tasks by passing UTC `available_at` through django-queues 1.2.0.
 - Require Redis 7+ and a deployed django-queues Redis Function library.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "David Nugent", email = "davidn@uniquode.io" }
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
## Overview

Prepare the repository for the v1.0.0 release by running CI on `main` and aligning package metadata with a stable release.

## Changes

- Run Test and Build CI on push to `main` and on manual dispatch, in addition to pull requests.
- Mark the package Production/Stable.
- Date the v1.0.0 changelog entry 2026-08-24.

## Impact

Merges to `main` report a test status, so the README tests badge can go green. PyPI classifiers no longer describe the package as alpha.

## Notes

The unpublished v1.0.0a1 changelog entry is left undated.
