### PR TITLE
UT-383: Collect Django task tests against RedisBackend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add a link to django.tasks documentation in the Usage section.
+- Dynamically pull and locally cache Django _current-version_ tests/tasks and run with the test suite against this implementation to ensure full interoperability.
+
 ## v1.0.0 - 2026-08-24
 
 - Support Django `run_after` deferred tasks by passing UTC `available_at` through django-queues 1.2.0.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ specific boundaries through its thread bridge.
 
 ## Usage
 
+Task definition, enqueueing, and result handling are Django's
+[`django.tasks` API](https://docs.djangoproject.com/en/6.1/topics/tasks/).
+This package provides the Redis backend; Django's documentation covers `@task`,
+`enqueue` / `aenqueue`, and `TaskResult`.
+
 A task is created using Django's `@task` decorator:
 
 ```python

--- a/conftest.py
+++ b/conftest.py
@@ -1,1 +1,64 @@
+from collections.abc import Iterator
+
+import django_queue
+import pytest
+import redis
+from django.conf import settings
+from django_queue.backends.redis.functions import load_function_library
+from testcontainers.community.redis import RedisContainer
+
 pytest_plugins = ["tests.django_src"]
+
+_REDIS_IMAGE = "redis:7-alpine"
+
+
+def _deploy_django_queues_functions(redis_url: str) -> None:
+    """Load the bundled Function library, equivalent to ``redis_lua_lib --deploy``."""
+    library = load_function_library()
+    client = redis.Redis.from_url(redis_url)
+    try:
+        version = client.info("server")["redis_version"]
+        major = int(str(version).split(".", 1)[0])
+        if major < 7:
+            raise RuntimeError(f"django-queues 1.2.0 requires Redis 7+, not {version}")
+        client.function_load(library.source.decode("utf-8"), replace=True)
+    finally:
+        client.close()
+
+
+def _point_django_queues_at(redis_url: str) -> None:
+    settings.QUEUES["default"]["LOCATION"] = redis_url
+    queue_settings = django_queue.queues.settings
+    queue_settings["default"]["LOCATION"] = redis_url
+    django_queue.queues.close_all()
+
+
+def _clear_default_task_queue() -> None:
+    queue = django_queue.queues["default"]
+    queue._run_synchronously(queue._provider.aclear_records)
+
+
+@pytest.fixture(scope="session")
+def redis_url() -> Iterator[str]:
+    """Session Redis for both package tests and Django tests collected from cache."""
+    with RedisContainer(_REDIS_IMAGE) as redis_container:
+        host = redis_container.get_container_host_ip()
+        port = redis_container.get_exposed_port(6379)
+        redis_url = f"redis://{host}:{port}/0"
+        _deploy_django_queues_functions(redis_url)
+        _point_django_queues_at(redis_url)
+        yield redis_url
+
+
+@pytest.fixture(autouse=True)
+def django_task_test_isolation(request):
+    module_name = getattr(request.module, "__name__", "")
+    if module_name != "tasks.test_tasks":
+        yield
+        return
+    request.getfixturevalue("redis_url")
+    _clear_default_task_queue()
+    try:
+        yield
+    finally:
+        _clear_default_task_queue()

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["tests.django_src"]

--- a/openspec/changes/use-django-tasks-tests/design.md
+++ b/openspec/changes/use-django-tasks-tests/design.md
@@ -36,8 +36,9 @@ This package already uses pytest with `settings.configure` in
 - Point Django's default task backend at `RedisBackend` plus the existing
   Redis testcontainer via Django settings, not by rewriting test methods.
 - Keep Django's test files out of this git tree. Cache a throwaway copy
-  locally in a directory pinned to the installed Django version; reuse it on
-  later pytest runs; discard (or prune) that directory when Django is bumped.
+  locally as `.django-src-<version>_cache/` (gitignored via `.*_cache`);
+  reuse it on later pytest runs; discard (or prune) that directory when
+  Django is bumped. Exclude it from ruff and ty.
 
 **Non-Goals:**
 
@@ -79,37 +80,111 @@ Rejected: this repo's default command is pytest; pytest-django is the bridge.
 ### Version-pinned local cache (fetch once per installed Django)
 
 `django.tasks` has no tests on the wheel. Resolve Django **source** for the
-exact installed version (`django.get_version()`, e.g. `6.1`) and add that
-tree's `tests/` directory to pytest's `pythonpath` so `import tasks` is
-Django's test package (`tasks.tasks`, `tasks.test_tasks`). Add `tests/tasks/`
-to collection (not only this repo's `tests/`).
+exact installed version (`django.get_version()`) and put that
+version's `tests/tasks/` tree on pytest's `pythonpath` as the `tasks`
+package (`tasks.tasks`, `tasks.test_tasks`). Collect from that package (not
+only this repo's `tests/`).
+
+`django.get_version()` is the cache-dir and GitHub-tag key. Django omits a
+trailing `.0`, so this is already upgrade-safe:
+
+- 6.1.0 → `6.1` → `.django-src-6.1_cache` and tag `6.1`
+- 6.1.1 → `6.1.1` → `.django-src-6.1.1_cache` and tag `6.1.1`
+- 6.2.0 → `6.2` → `.django-src-6.2_cache` and tag `6.2`
+
+A bump looks at a new directory; the old one is unused. Do not hard-code
+`6.1` in the resolver.
+
+Layout (shallow, one cache dir per version):
+
+```
+.django-src-6.1_cache/     # gitignored by .*_cache; name follows get_version()
+  tasks/                   # Django's tests/tasks/ only
+    __init__.py
+    tasks.py
+    test_tasks.py
+    …
+```
+
+`pythonpath` includes `.django-src-<version>_cache` so `import tasks` is
+Django's test package. Do not nest under `.cache/django-src/<version>/`.
+Do not extract `django/`, `tests/runtests.py`, or `tests/test_utils/`.
+
+The installed wheel already provides the library (`django.tasks`,
+`django.test.SimpleTestCase`, Dummy/Immediate backends). Django 6.1's
+`tests/tasks/` imports only `django.*` and relative `. import tasks`. It
+does not need `runtests.py`, `test_utils`, or other project-test helpers.
 
 Resolution order:
 
-1. `DJANGO_TESTS_ROOT` if set (local Django checkout's `tests/` directory).
-2. Gitignored cache directory **named for that exact version**, e.g.
-   `.cache/django-src/<version>/`. If that directory already contains a usable
-   `tests/tasks/` tree, reuse it. Do **not** fetch or unpack on every pytest
-   run.
-3. On a miss for that version only: copy **`tests/tasks/`** from GitHub at
-   the tag that matches the installed version (`django.get_version()`, e.g.
-   tag `6.1`). Do **not** keep a full Django checkout in the cache. A sparse
-   clone (`git clone --depth 1 --filter=blob:none --sparse --branch <tag>`
-   then `git sparse-checkout set tests/tasks`) or extracting only that
-   subtree from the tag archive is fine. Recursively materialize that
-   directory into `.cache/django-src/<version>/`, then drop any leftover
-   `.git` / unused archive members.
+1. `DJANGO_TESTS_ROOT` if set (that checkout's `tests/` directory, so
+   `DJANGO_TESTS_ROOT/tasks/` is the test package).
+2. Gitignored `.django-src-<version>_cache/`. If `tasks/test_tasks.py`
+   is already present, reuse it. Do **not** fetch or unpack on every
+   pytest run.
+3. On a miss for that version only: download the GitHub **tag archive**
+   for `django.get_version()` (e.g.
+   `https://github.com/django/django/archive/refs/tags/6.1.tar.gz`) and
+   extract only members under `*/tests/tasks/` into
+   `.django-src-<version>_cache/tasks/`. Prefer an atomic write (extract
+   to a temp dir, then rename). Do not sparse-clone the whole Django repo.
 4. Fail collection with a clear error if unresolved (unknown tag, network
-   failure, empty `tests/tasks/`).
+   failure, empty `tasks/` tree).
 
-When Django is upgraded, pytest looks at a **new** version directory. Older
-sibling directories under the cache root are leftover and MAY be deleted
-automatically after the current version resolves, so stale trees do not
-accumulate. They are never committed.
+When Django is upgraded, pytest looks at a **new** `.django-src-<new>_cache`
+directory. Older `.django-src-*_cache` siblings MAY be deleted after the
+current version resolves. They are never committed.
+
+Exclude `.django-src-*_cache` from ruff (`extend-exclude`). ty already
+limits `include` to `redis_tasks`, so it will not type-check the cache.
 
 `pyproject.toml` cannot hard-code a versioned cache path. A pytest hook
 (conftest / small plugin) registers the resolved path at configure time.
 That hook is this repo's pytest config, not a copy of Django tests.
+
+### How it folds into `uv run pytest`
+
+Same process as today (`uv run pytest` / CI `uv run pytest -Walways -Werror`).
+No second command, job, or marker. The cache is not a pytest plugin for Django;
+it is an extra collection root registered at configure time.
+
+1. **Configure (before collection).** `tests/conftest.py` (or a tiny local
+   pytest plugin it loads) runs in `pytest_configure`:
+   - Read `django.get_version()` from the installed wheel.
+   - Resolve `DJANGO_TESTS_ROOT` or `.django-src-<version>_cache/` (fetch
+     once on miss).
+   - Insert the cache **root** on `sys.path` so `import tasks` is Django's
+     test package.
+   - If this run is the default suite (`config.args` is the ini `testpaths`,
+     i.e. `tests/`, not an explicit file path), append that cache root (or
+     `…/tasks/`) to `config.args` so pytest collects it.
+   - `collect_ignore` / path filter drops `test_dummy_backend.py`,
+     `test_immediate_backend.py`, `test_custom_backend.py`.
+   - Method-level skips for Dummy `.results` / Immediate SUCCESSFUL-on-enqueue
+     are registered here (names, not rewritten bodies).
+2. **Django setup (same configure phase, pytest-django).**
+   `DJANGO_SETTINGS_MODULE` points at a suite settings module:
+   `TASKS["default"]` is `RedisBackend`. This replaces ad-hoc
+   `settings.configure` so there is one setup path. pytest-django then runs
+   `SimpleTestCase` natively (including Django's async test methods).
+3. **Session: Redis testcontainer.** Django's `TaskTestCase` will not request
+   today's `redis_url` / `task_queue` fixtures. A session-scoped (or autouse)
+   fixture starts the existing Redis testcontainer, writes its URL into
+   `settings.QUEUES[*]["LOCATION"]`, and clears queue records between tests
+   the same way `task_queue` does. Package tests keep using that Redis.
+4. **Collection.** Two roots in one run:
+   - `tests/` — this package's tests (unchanged node ids).
+   - `.django-src-<version>_cache/tasks/` — Django's `test_*.py` as unittest
+     `TaskTestCase` nodes (`tasks/test_tasks.py::TaskTestCase::test_…`).
+   An explicit path (`pytest tests/test_redis_backend.py`) does **not** pull
+   in Django's suite; only the default command does.
+5. **Run.** Failures from either root fail the same pytest process. ruff and
+   ty are not invoked on the cache; they are separate tools and exclude it.
+
+Cold cache: first default pytest for a version may hit the network during
+`pytest_configure`. Later runs for that version are local and look like any
+other extra test directory. Offline + missing cache fails collection with a
+message that names the version and expected path.
 
 ### Default `TASKS` is RedisBackend
 
@@ -132,12 +207,15 @@ Clear queue records between tests the same way `task_queue` does today.
   replaces the default alias; skip methods that only make sense for Dummy or
   Immediate.
 - **[Risk] Cold cache needs network.** → Mitigation: fetch only when
-  `.cache/django-src/<installed-version>/` is missing; later pytest runs for
+  `.django-src-<installed-version>_cache/` is missing; later pytest runs for
   the same version are local. `DJANGO_TESTS_ROOT` skips the cache. Fail loudly
   if missing and offline.
 - **[Risk] Cache grows after Django bumps.** → Mitigation: directory name is
-  the installed version; old version dirs are discardable and MAY be pruned
-  once the current version is resolved.
+  `.django-src-<version>_cache`; old version dirs are discardable and MAY be
+  pruned once the current version is resolved.
+- **[Risk] ruff/format walks the cache.** → Mitigation: `extend-exclude`
+  `.django-src-*_cache`; the directory is gitignored so pre-commit will not
+  see it unless someone stages it.
 - **[Trade-off] pytest-django is a new dev dependency.** Accepted: it is how
   pytest runs Django tests seamlessly.
 

--- a/openspec/changes/use-django-tasks-tests/design.md
+++ b/openspec/changes/use-django-tasks-tests/design.md
@@ -117,19 +117,18 @@ does not need `runtests.py`, `test_utils`, or other project-test helpers.
 
 Resolution order:
 
-1. `DJANGO_TESTS_ROOT` if set (that checkout's `tests/` directory, so
-   `DJANGO_TESTS_ROOT/tasks/` is the test package).
-2. Gitignored `.django-src-<version>_cache/`. If `tasks/test_tasks.py`
+1. Gitignored `.django-src-<version>_cache/`. If `tasks/test_tasks.py`
    is already present, reuse it. Do **not** fetch or unpack on every
    pytest run.
-3. On a miss for that version only: download the GitHub **tag archive**
+2. On a miss for that version only: download the GitHub **tag archive**
    for `django.get_version()` (e.g.
    `https://github.com/django/django/archive/refs/tags/6.1.tar.gz`) and
    extract only members under `*/tests/tasks/` into
    `.django-src-<version>_cache/tasks/`. Prefer an atomic write (extract
    to a temp dir, then rename). Do not sparse-clone the whole Django repo.
-4. Fail collection with a clear error if unresolved (unknown tag, network
-   failure, empty `tasks/` tree).
+3. Fail collection with a clear error if unresolved (unknown tag, network
+   failure, empty `tasks/` tree). The message names the Django version and
+   the expected cache path.
 
 When Django is upgraded, pytest looks at a **new** `.django-src-<new>_cache`
 directory. Older `.django-src-*_cache` siblings MAY be deleted after the
@@ -151,8 +150,7 @@ it is an extra collection root registered at configure time.
 1. **Configure (before collection).** `tests/conftest.py` (or a tiny local
    pytest plugin it loads) runs in `pytest_configure`:
    - Read `django.get_version()` from the installed wheel.
-   - Resolve `DJANGO_TESTS_ROOT` or `.django-src-<version>_cache/` (fetch
-     once on miss).
+   - Resolve `.django-src-<version>_cache/` (fetch once on miss).
    - Insert the cache **root** on `sys.path` so `import tasks` is Django's
      test package.
    - If this run is the default suite (`config.args` is the ini `testpaths`,
@@ -167,11 +165,12 @@ it is an extra collection root registered at configure time.
    `TASKS["default"]` is `RedisBackend`. This replaces ad-hoc
    `settings.configure` so there is one setup path. pytest-django then runs
    `SimpleTestCase` natively (including Django's async test methods).
-3. **Session: Redis testcontainer.** Django's `TaskTestCase` will not request
-   today's `redis_url` / `task_queue` fixtures. A session-scoped (or autouse)
-   fixture starts the existing Redis testcontainer, writes its URL into
-   `settings.QUEUES[*]["LOCATION"]`, and clears queue records between tests
-   the same way `task_queue` does. Package tests keep using that Redis.
+3. **Session: Redis testcontainer.** Root `conftest.py` owns session
+   `redis_url` and autouse isolation so both `tests/` and
+   `.django-src-*_cache/` see the testcontainer. It writes the container URL
+   into `settings.QUEUES[*]["LOCATION"]` and clears queue records around
+   imported Django cases. Package tests keep `task_queue` / `redis_backend`
+   in `tests/conftest.py`.
 4. **Collection.** Two roots in one run:
    - `tests/` — this package's tests (unchanged node ids).
    - `.django-src-<version>_cache/tasks/` — Django's `test_*.py` as unittest
@@ -208,8 +207,7 @@ Clear queue records between tests the same way `task_queue` does today.
   Immediate.
 - **[Risk] Cold cache needs network.** → Mitigation: fetch only when
   `.django-src-<installed-version>_cache/` is missing; later pytest runs for
-  the same version are local. `DJANGO_TESTS_ROOT` skips the cache. Fail loudly
-  if missing and offline.
+  the same version are local. Fail loudly if missing and offline.
 - **[Risk] Cache grows after Django bumps.** → Mitigation: directory name is
   `.django-src-<version>_cache`; old version dirs are discardable and MAY be
   pruned once the current version is resolved.

--- a/openspec/changes/use-django-tasks-tests/proposal.md
+++ b/openspec/changes/use-django-tasks-tests/proposal.md
@@ -11,11 +11,11 @@ inferred, not proven, and Django upgrades can change the contract unnoticed.
   (`SimpleTestCase`, pytest-django, `python_files` including `tests.py`). Do
   not commit those files and do not re-host test methods as pytest functions.
 - Keep a gitignored throwaway copy of Django's **`tests/tasks/`** subtree
-  only, in a directory named for the exact installed Django version. On a
-  cache miss, copy that path from GitHub at the matching version tag (sparse
-  clone or tag-archive extract of that directory). Do not fetch or unpack on
-  later pytest runs. When Django is upgraded, use a new directory and discard
-  the old one. Do not keep a full Django checkout.
+  only, in `.django-src-<version>_cache/` (matches `.*_cache` in
+  `.gitignore`). On a cache miss, extract that path from the GitHub tag
+  archive. Do not fetch or unpack on later pytest runs. When Django is
+  upgraded, use a new directory and discard the old one. Do not keep a full
+  Django checkout. Do not run ruff or ty on the cache.
 - Collect only tests that apply to a third-party `BaseTaskBackend`. Do not
   collect DummyBackend, ImmediateBackend, or custom-backend modules.
 - Default Django `TASKS` under pytest is `RedisBackend` plus the existing Redis

--- a/openspec/changes/use-django-tasks-tests/specs/django-tasks-test-compliance/spec.md
+++ b/openspec/changes/use-django-tasks-tests/specs/django-tasks-test-compliance/spec.md
@@ -35,7 +35,8 @@ repository.
 #### Scenario: Old cache is discardable after a Django upgrade
 - **WHEN** the installed Django version changes
 - **THEN** the previous version's cached tree is no longer used, and that
-  version-named cache directory can be deleted without affecting the new run
+  version-named `.django-src-<version>_cache` directory can be deleted without
+  affecting the new run
 
 #### Scenario: Imported tests use the Redis task backend
 - **WHEN** an imported contract test enqueues or looks up a task through Django's

--- a/openspec/changes/use-django-tasks-tests/tasks.md
+++ b/openspec/changes/use-django-tasks-tests/tasks.md
@@ -1,51 +1,52 @@
 ## 1. Pytest runs Django tests
 
-- [ ] 1.1 Add pytest-django and a `DJANGO_SETTINGS_MODULE` for the suite
+- [x] 1.1 Add pytest-django and a `DJANGO_SETTINGS_MODULE` for the suite
       (`python_files` includes `test_*.py` and `tests.py`) and verify
       `SimpleTestCase` tests collect and run under `uv run pytest`.
-- [ ] 1.2 Point default `TASKS` at `RedisBackend` and `QUEUES` at the existing
+- [x] 1.2 Point default `TASKS` at `RedisBackend` and `QUEUES` at the existing
       Redis testcontainer in that settings module, and verify
       `default_task_backend` is `RedisBackend` during collected Django tests.
-- [ ] 1.3 Move existing package tests off ad-hoc `settings.configure` if it
+- [x] 1.3 Move existing package tests off ad-hoc `settings.configure` if it
       conflicts with pytest-django, and verify `tests/test_redis_backend.py`
       still passes.
 
 ## 2. Collect Django's `tests/tasks/` for the installed version
 
-- [ ] 2.1 Resolve Django's `tests/tasks/` tree for `django.get_version()`
-      (`DJANGO_TESTS_ROOT`, else gitignored `.cache/django-src/<version>/`,
-      else one path-limited fetch from GitHub at that version tag: sparse
-      clone or tag-archive extract of `tests/tasks/` only) and register it on
-      pytest's pythonpath/collection path; verify the cache is not a full
-      Django checkout, `import tasks` is Django's test package,
-      `tasks.test_tasks` is collected, and a second pytest run for the same
-      version does not fetch again.
-- [ ] 2.2 Fail collection with a clear error when the tree cannot be resolved,
+- [x] 2.1 Resolve Django's `tests/tasks/` tree for `django.get_version()`
+      (`DJANGO_TESTS_ROOT`, else gitignored `.django-src-<version>_cache/tasks/`,
+      else one GitHub tag-archive extract of `tests/tasks/` only into that
+      cache) and register it on pytest's pythonpath/collection path; verify
+      the cache is not a full Django checkout, `import tasks` is Django's
+      test package, `tasks.test_tasks` is collected, and a second pytest run
+      for the same version does not fetch again.
+- [x] 2.2 Fail collection with a clear error when the tree cannot be resolved,
       and verify the message names the Django version and expected path.
-- [ ] 2.3 Ignore Dummy, Immediate, and custom-backend modules via pytest
+- [x] 2.3 Ignore Dummy, Immediate, and custom-backend modules via pytest
       collect config; verify pytest does not collect `test_dummy_backend`,
       `test_immediate_backend`, or `test_custom_backend`.
-- [ ] 2.4 Confirm no Django test source is committed; verify `git ls-files`
+- [x] 2.4 Confirm no Django test source is committed; verify `git ls-files`
       has no copy of Django's `tests/tasks/` files.
-- [ ] 2.5 After resolving the current version, unused sibling version
-      directories under the cache root are pruneable; verify a leftover
-      `.cache/django-src/<old-version>/` is not used once Django is bumped.
+- [x] 2.5 After resolving the current version, unused sibling
+      `.django-src-*_cache` directories are pruneable; verify a leftover
+      `.django-src-<old-version>_cache/` is not used once Django is bumped.
+- [x] 2.6 Exclude `.django-src-*_cache` from ruff; verify ruff/ty do not
+      lint or type-check files in that directory.
 
 ## 3. Dummy/Immediate assertions inside TaskTestCase
 
-- [ ] 3.1 Skip Dummy `.results`, default-is-Dummy, Dummy `.clear()`, and
+- [x] 3.1 Skip Dummy `.results`, default-is-Dummy, Dummy `.clear()`, and
       Immediate SUCCESSFUL-on-enqueue / Immediate `TaskError` execution
       methods; verify those names are skipped or absent, not rewritten to pass.
-- [ ] 3.2 Leave Django's `module_path` assertions (`tasks.tasks.*`) intact and
+- [x] 3.2 Leave Django's `module_path` assertions (`tasks.tasks.*`) intact and
       verify `import_string` round-trips Task instances from Django's fixture
       module.
-- [ ] 3.3 Clear queue records between Django `TaskTestCase` tests using the
+- [x] 3.3 Clear queue records between Django `TaskTestCase` tests using the
       same pattern as `task_queue`, and verify consecutive enqueue tests do
       not share leftover entries.
 
 ## 4. Default-suite verification
 
-- [ ] 4.1 Run `uv run pytest` and verify Django's applicable `SimpleTestCase`
+- [x] 4.1 Run `uv run pytest` and verify Django's applicable `SimpleTestCase`
       contract tests run against Redis and pass with the rest of the package
       suite.
-- [ ] 4.2 Run ruff and ty on the pytest hook/settings and verify they pass.
+- [x] 4.2 Run ruff and ty on the pytest hook/settings and verify they pass.

--- a/openspec/changes/use-django-tasks-tests/tasks.md
+++ b/openspec/changes/use-django-tasks-tests/tasks.md
@@ -13,9 +13,9 @@
 ## 2. Collect Django's `tests/tasks/` for the installed version
 
 - [x] 2.1 Resolve Django's `tests/tasks/` tree for `django.get_version()`
-      (`DJANGO_TESTS_ROOT`, else gitignored `.django-src-<version>_cache/tasks/`,
-      else one GitHub tag-archive extract of `tests/tasks/` only into that
-      cache) and register it on pytest's pythonpath/collection path; verify
+      (gitignored `.django-src-<version>_cache/tasks/`, else one GitHub
+      tag-archive extract of `tests/tasks/` only into that cache) and register
+      it on pytest's pythonpath/collection path; verify
       the cache is not a full Django checkout, `import tasks` is Django's
       test package, `tasks.test_tasks` is collected, and a second pytest run
       for the same version does not fetch again.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,12 @@ minversion = "8.0"
 asyncio_default_fixture_loop_scope = "function"
 pythonpath = ["."]
 testpaths = ["tests"]
+python_files = ["test_*.py", "tests.py"]
+DJANGO_SETTINGS_MODULE = "tests.settings"
+django_find_project = false
+
+[tool.ruff]
+extend-exclude = [".django-src-*_cache"]
 
 [dependency-groups]
 dev = [
@@ -42,6 +48,7 @@ dev = [
     "testcontainers>=4.9.0",
     "ty>=0.0.69",
     "pytest-asyncio>=0.25.0",
+    "pytest-django>=4.14.0",
 ]
 [tool.uv]
 default-groups = ["dev"]

--- a/redis_tasks/backend.py
+++ b/redis_tasks/backend.py
@@ -1,5 +1,7 @@
 import builtins
 import uuid
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from typing import Any, cast
 
@@ -215,6 +217,23 @@ def _enqueue_options(task: Task) -> dict[str, Any]:
     return options
 
 
+def _call_sync_from_any_thread[T](
+    func: Callable[..., T], *args: Any, **kwargs: Any
+) -> T:
+    """Run a django-queue sync API from sync or async tests.
+
+    ``AsyncQueue.find`` uses ``async_to_sync``, which cannot run on a thread
+    that already has an event loop (Django's ``async def`` tests).
+    """
+    try:
+        return func(*args, **kwargs)
+    except RuntimeError as exc:
+        if "async event loop" not in str(exc):
+            raise
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(func, *args, **kwargs).result()
+
+
 class RedisBackend(BaseTaskBackend):
     supports_async_task = True
     supports_get_result = True
@@ -230,8 +249,7 @@ class RedisBackend(BaseTaskBackend):
             )
         if self._queue_alias not in django_queue.queues.settings:
             raise ImproperlyConfigured(
-                f"Redis task backend queue_alias {self._queue_alias!r} is not "
-                "configured in QUEUES."
+                f"Redis task backend queue_alias {self._queue_alias!r} is not configured in QUEUES."
             )
         try:
             queue_backend = import_string(
@@ -240,13 +258,11 @@ class RedisBackend(BaseTaskBackend):
             is_redis_queue = issubclass(queue_backend, RedisAsyncQueue)
         except (ImportError, AttributeError, TypeError) as exc:
             raise ImproperlyConfigured(
-                f"Redis task backend queue_alias {self._queue_alias!r} must use a "
-                "RedisAsyncQueue-compatible backend."
+                f"Redis task backend queue_alias {self._queue_alias!r} must use a RedisAsyncQueue-compatible backend."
             ) from exc
         if not is_redis_queue:
             raise ImproperlyConfigured(
-                f"Redis task backend queue_alias {self._queue_alias!r} must use a "
-                "RedisAsyncQueue-compatible backend."
+                f"Redis task backend queue_alias {self._queue_alias!r} must use a RedisAsyncQueue-compatible backend."
             )
         entry_class = django_queue.queues.settings[self._queue_alias].get("ENTRY_CLASS")
         if isinstance(entry_class, str):
@@ -312,7 +328,7 @@ class RedisBackend(BaseTaskBackend):
     def get_result(self, result_id: str) -> TaskResult:
         entry_id = self._parse_result_id(result_id)
         try:
-            entry = self._resolve_queue().find(entry_id)
+            entry = _call_sync_from_any_thread(self._resolve_queue().find, entry_id)
         except QueueEntryNotFoundError as exc:
             raise TaskResultDoesNotExist(result_id) from exc
         return self._result_from_stored_entry(cast(TaskQueueEntry, entry), result_id)
@@ -324,3 +340,7 @@ class RedisBackend(BaseTaskBackend):
         except QueueEntryNotFoundError as exc:
             raise TaskResultDoesNotExist(result_id) from exc
         return self._result_from_stored_entry(cast(TaskQueueEntry, entry), result_id)
+
+    def clear(self) -> None:
+        queue = self._resolve_queue()
+        queue._run_synchronously(queue._provider.aclear_records)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,47 +1,14 @@
 import os
-from collections.abc import Iterator
 
 import django_queue
 import pytest
-import redis
-from django.conf import settings
-from django_queue.backends.redis.functions import load_function_library
-from testcontainers.community.redis import RedisContainer
 
 from redis_tasks.backend import RedisBackend
 from tests.django_src import DjangoTasksSourceError, register_django_tasks_collection
 
-_REDIS_IMAGE = "redis:7-alpine"
-
-
-def _deploy_django_queues_functions(redis_url: str) -> None:
-    """Load the bundled Function library, equivalent to ``redis_lua_lib --deploy``."""
-    library = load_function_library()
-    client = redis.Redis.from_url(redis_url)
-    try:
-        version = client.info("server")["redis_version"]
-        major = int(str(version).split(".", 1)[0])
-        if major < 7:
-            raise RuntimeError(f"django-queues 1.2.0 requires Redis 7+, not {version}")
-        client.function_load(library.source.decode("utf-8"), replace=True)
-    finally:
-        client.close()
-
 
 def _slow_tests_enabled():
     return os.getenv("SLOW_TESTS") in ("true", "1", "enabled")
-
-
-def _point_django_queues_at(redis_url: str) -> None:
-    settings.QUEUES["default"]["LOCATION"] = redis_url
-    queue_settings = django_queue.queues.settings
-    queue_settings["default"]["LOCATION"] = redis_url
-    django_queue.queues.close_all()
-
-
-def _clear_default_task_queue() -> None:
-    queue = django_queue.queues["default"]
-    queue._run_synchronously(queue._provider.aclear_records)
 
 
 def pytest_configure(config):
@@ -56,17 +23,6 @@ def pytest_configure(config):
         register_django_tasks_collection(config)
     except DjangoTasksSourceError as exc:
         raise pytest.UsageError(str(exc)) from exc
-
-
-@pytest.fixture(scope="session")
-def redis_url() -> Iterator[str]:
-    with RedisContainer(_REDIS_IMAGE) as redis_container:
-        host = redis_container.get_container_host_ip()
-        port = redis_container.get_exposed_port(6379)
-        redis_url = f"redis://{host}:{port}/0"
-        _deploy_django_queues_functions(redis_url)
-        _point_django_queues_at(redis_url)
-        yield redis_url
 
 
 @pytest.fixture
@@ -94,17 +50,3 @@ def redis_backend(task_queue, monkeypatch):
     backend = RedisBackend(alias="default", params={"QUEUES": ["default", "alternate"]})
     monkeypatch.setattr(backend, "_resolve_queue", lambda: task_queue)
     return backend
-
-
-@pytest.fixture(autouse=True)
-def django_task_test_isolation(request):
-    module_name = getattr(request.module, "__name__", "")
-    if module_name != "tasks.test_tasks":
-        yield
-        return
-    request.getfixturevalue("redis_url")
-    _clear_default_task_queue()
-    try:
-        yield
-    finally:
-        _clear_default_task_queue()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from django_queue.backends.redis.functions import load_function_library
 from testcontainers.community.redis import RedisContainer
 
 from redis_tasks.backend import RedisBackend
+from tests.django_src import DjangoTasksSourceError, register_django_tasks_collection
 
 _REDIS_IMAGE = "redis:7-alpine"
 
@@ -31,6 +32,18 @@ def _slow_tests_enabled():
     return os.getenv("SLOW_TESTS") in ("true", "1", "enabled")
 
 
+def _point_django_queues_at(redis_url: str) -> None:
+    settings.QUEUES["default"]["LOCATION"] = redis_url
+    queue_settings = django_queue.queues.settings
+    queue_settings["default"]["LOCATION"] = redis_url
+    django_queue.queues.close_all()
+
+
+def _clear_default_task_queue() -> None:
+    queue = django_queue.queues["default"]
+    queue._run_synchronously(queue._provider.aclear_records)
+
+
 def pytest_configure(config):
     config.addinivalue_line(
         "markers", "slow: mark test as slow (skipped unless SLOW_TESTS=true/1/enabled)"
@@ -39,33 +52,20 @@ def pytest_configure(config):
         not _slow_tests_enabled(),
         reason="Test skipped because SLOW_TESTS environment variable not set to true, 1 or enabled",
     )
-    if not settings.configured:
-        settings.configure(
-            USE_TZ=True,
-            TASKS={
-                "default": {
-                    "BACKEND": "redis_tasks.backend.RedisBackend",
-                    "QUEUES": ["default", "alternate"],
-                }
-            },
-            QUEUES={
-                "default": {
-                    "BACKEND": "django_queue.backends.redis.RedisAsyncPriorityQueueJson",
-                    "LOCATION": "redis://localhost:6379/0",
-                    "ENTRY_CLASS": "redis_tasks.entries.TaskQueueEntry",
-                    "WORKER": "redis_tasks.worker.RedisTaskWorker",
-                }
-            },
-        )
+    try:
+        register_django_tasks_collection(config)
+    except DjangoTasksSourceError as exc:
+        raise pytest.UsageError(str(exc)) from exc
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def redis_url() -> Iterator[str]:
     with RedisContainer(_REDIS_IMAGE) as redis_container:
         host = redis_container.get_container_host_ip()
         port = redis_container.get_exposed_port(6379)
         redis_url = f"redis://{host}:{port}/0"
         _deploy_django_queues_functions(redis_url)
+        _point_django_queues_at(redis_url)
         yield redis_url
 
 
@@ -94,3 +94,17 @@ def redis_backend(task_queue, monkeypatch):
     backend = RedisBackend(alias="default", params={"QUEUES": ["default", "alternate"]})
     monkeypatch.setattr(backend, "_resolve_queue", lambda: task_queue)
     return backend
+
+
+@pytest.fixture(autouse=True)
+def django_task_test_isolation(request):
+    module_name = getattr(request.module, "__name__", "")
+    if module_name != "tasks.test_tasks":
+        yield
+        return
+    request.getfixturevalue("redis_url")
+    _clear_default_task_queue()
+    try:
+        yield
+    finally:
+        _clear_default_task_queue()

--- a/tests/django_src.py
+++ b/tests/django_src.py
@@ -9,11 +9,10 @@ import tarfile
 import tempfile
 import urllib.error
 import urllib.request
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-DJANGO_TESTS_ROOT_ENV = "DJANGO_TESTS_ROOT"
 IGNORED_TASK_MODULES = frozenset(
     {
         "test_dummy_backend.py",
@@ -169,21 +168,9 @@ def resolve_django_tasks_root(
     *,
     version: str,
     project_root: Path,
-    env: Mapping[str, str] | None = None,
     download: Download | None = None,
 ) -> Path:
     """Return the pythonpath root whose ``tasks`` package is Django's tests/tasks."""
-    environ = os.environ if env is None else env
-    tests_root = environ.get(DJANGO_TESTS_ROOT_ENV)
-    if tests_root:
-        root = Path(tests_root)
-        expected = expected_test_tasks_path(root)
-        if not expected.is_file():
-            raise DjangoTasksSourceError(
-                f"Could not resolve Django {version} tests/tasks; expected {expected}"
-            )
-        return root
-
     dest_root = cache_root(project_root, version)
     expected = expected_test_tasks_path(dest_root)
     if expected.is_file():
@@ -199,9 +186,7 @@ def resolve_django_tasks_root(
         archive_path = Path(tmp) / "django.tar.gz"
         try:
             fetch(url, archive_path)
-        except DjangoTasksSourceError:
-            raise
-        except OSError as exc:
+        except (DjangoTasksSourceError, OSError) as exc:
             raise DjangoTasksSourceError(
                 f"Could not resolve Django {version} tests/tasks; expected {expected}"
             ) from exc

--- a/tests/django_src.py
+++ b/tests/django_src.py
@@ -1,0 +1,295 @@
+"""Resolve Django's tests/tasks tree for the installed Django version."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+DJANGO_TESTS_ROOT_ENV = "DJANGO_TESTS_ROOT"
+IGNORED_TASK_MODULES = frozenset(
+    {
+        "test_dummy_backend.py",
+        "test_immediate_backend.py",
+        "test_custom_backend.py",
+    }
+)
+SKIP_TASKTESTCASE_METHODS = frozenset(
+    {
+        "test_using_correct_backend",
+        "test_enqueue_task",
+        "test_enqueue_task_async",
+        "test_get_backend",
+        "test_task_error_invalid_exception",
+        "test_task_error_unknown_module",
+    }
+)
+
+Download = Callable[[str, Path], None]
+
+
+class DjangoTasksSourceError(Exception):
+    """Django's tests/tasks tree could not be resolved for this version."""
+
+
+def installed_django_version() -> str:
+    """PEP 440 string matching Django's GitHub tag (``6.1``, ``6.1.1``, ``6.2``)."""
+    import django
+
+    return django.get_version()
+
+
+def cache_dir_name(version: str) -> str:
+    return f".django-src-{version}_cache"
+
+
+def archive_url(version: str) -> str:
+    return f"https://github.com/django/django/archive/refs/tags/{version}.tar.gz"
+
+
+def cache_root(project_root: Path, version: str) -> Path:
+    return project_root / cache_dir_name(version)
+
+
+def expected_test_tasks_path(pythonpath_root: Path) -> Path:
+    return pythonpath_root / "tasks" / "test_tasks.py"
+
+
+def is_ignored_django_task_module(path: Path) -> bool:
+    return path.name in IGNORED_TASK_MODULES and path.parent.name == "tasks"
+
+
+def should_skip_django_task_item(item: Any) -> bool:
+    cls = getattr(item, "cls", None)
+    if cls is None:
+        return False
+    if getattr(cls, "__name__", None) != "TaskTestCase":
+        return False
+    if getattr(cls, "__module__", None) != "tasks.test_tasks":
+        return False
+    name = getattr(item, "originalname", None) or getattr(item, "name", "")
+    return name in SKIP_TASKTESTCASE_METHODS
+
+
+def should_collect_django_tasks(config: Any) -> bool:
+    root = Path(config.rootpath)
+    testpaths = [Path(path) for path in (config.getini("testpaths") or [])]
+    allowed_dirs = {
+        path.resolve() if path.is_absolute() else (root / path).resolve()
+        for path in testpaths
+    }
+    args = list(getattr(config, "args", []) or [])
+    if not args:
+        return True
+    for arg in args:
+        path_str = str(arg).split("::", 1)[0]
+        path = Path(path_str)
+        resolved = path.resolve() if path.is_absolute() else (root / path).resolve()
+        if resolved.is_file() or resolved.suffix == ".py":
+            return False
+        if allowed_dirs and resolved not in allowed_dirs:
+            return False
+    return True
+
+
+def extract_tasks_from_archive(archive_path: Path, dest_root: Path) -> None:
+    dest_root.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive_path, "r:gz") as tar:
+        for member in tar.getmembers():
+            parts = Path(member.name).parts
+            if ".." in parts:
+                continue
+            try:
+                tests_index = parts.index("tests")
+            except ValueError:
+                continue
+            if tests_index + 1 >= len(parts) or parts[tests_index + 1] != "tasks":
+                continue
+            relative = Path(*parts[tests_index + 1 :])
+            if ".." in relative.parts:
+                continue
+            target = dest_root / relative
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                continue
+            extracted = tar.extractfile(member)
+            if extracted is None:
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with extracted, target.open("wb") as output:
+                shutil.copyfileobj(extracted, output)
+
+
+def download_url_to_path(url: str, dest: Path) -> None:
+    try:
+        with urllib.request.urlopen(url) as response, dest.open("wb") as output:
+            shutil.copyfileobj(response, output)
+    except (urllib.error.URLError, OSError) as exc:
+        raise DjangoTasksSourceError(
+            f"Could not download Django source from {url}"
+        ) from exc
+
+
+def _unpack_archive_into_cache(
+    archive_path: Path, dest_root: Path, version: str
+) -> None:
+    expected = expected_test_tasks_path(dest_root)
+    parent = dest_root.parent
+    with tempfile.TemporaryDirectory(
+        prefix=f".django-src-{version}_", dir=parent
+    ) as tmp:
+        extracted = Path(tmp) / "extracted"
+        try:
+            extract_tasks_from_archive(archive_path, extracted)
+        except tarfile.TarError as exc:
+            raise DjangoTasksSourceError(
+                f"Could not resolve Django {version} tests/tasks; expected {expected}"
+            ) from exc
+        if not expected_test_tasks_path(extracted).is_file():
+            raise DjangoTasksSourceError(
+                f"Could not resolve Django {version} tests/tasks; expected {expected}"
+            )
+        staging = parent / f".django-src-{version}_cache.tmp"
+        if staging.exists():
+            shutil.rmtree(staging)
+        shutil.move(str(extracted), str(staging))
+        os.replace(staging, dest_root)
+
+
+def resolve_django_tasks_root(
+    *,
+    version: str,
+    project_root: Path,
+    env: Mapping[str, str] | None = None,
+    download: Download | None = None,
+) -> Path:
+    """Return the pythonpath root whose ``tasks`` package is Django's tests/tasks."""
+    environ = os.environ if env is None else env
+    tests_root = environ.get(DJANGO_TESTS_ROOT_ENV)
+    if tests_root:
+        root = Path(tests_root)
+        expected = expected_test_tasks_path(root)
+        if not expected.is_file():
+            raise DjangoTasksSourceError(
+                f"Could not resolve Django {version} tests/tasks; expected {expected}"
+            )
+        return root
+
+    dest_root = cache_root(project_root, version)
+    expected = expected_test_tasks_path(dest_root)
+    if expected.is_file():
+        return dest_root
+
+    url = archive_url(version)
+    fetch = download_url_to_path if download is None else download
+    parent = dest_root.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        prefix=f".django-src-{version}_dl_", dir=parent
+    ) as tmp:
+        archive_path = Path(tmp) / "django.tar.gz"
+        try:
+            fetch(url, archive_path)
+        except DjangoTasksSourceError:
+            raise
+        except OSError as exc:
+            raise DjangoTasksSourceError(
+                f"Could not resolve Django {version} tests/tasks; expected {expected}"
+            ) from exc
+        _unpack_archive_into_cache(archive_path, dest_root, version)
+    if not expected.is_file():
+        raise DjangoTasksSourceError(
+            f"Could not resolve Django {version} tests/tasks; expected {expected}"
+        )
+    return dest_root
+
+
+REDIS_TASK_BACKEND = "redis_tasks.backend.RedisBackend"
+
+
+def apply_redis_default_to_tasktestcase(cls: Any) -> None:
+    """Keep Django's TaskTestCase aliases; point default at RedisBackend."""
+    overridden = getattr(cls, "_overridden_settings", None)
+    if not isinstance(overridden, dict):
+        return
+    tasks_cfg = overridden.get("TASKS")
+    if not isinstance(tasks_cfg, dict) or "default" not in tasks_cfg:
+        return
+    default_cfg = dict(tasks_cfg["default"])
+    default_cfg["BACKEND"] = REDIS_TASK_BACKEND
+    tasks_cfg = dict(tasks_cfg)
+    tasks_cfg["default"] = default_cfg
+    overridden["TASKS"] = tasks_cfg
+
+
+def register_django_tasks_collection(
+    config: Any,
+    *,
+    version: str | None = None,
+    project_root: Path | None = None,
+    download: Download | None = None,
+) -> Path | None:
+    """Put Django's tests/tasks on sys.path and pytest's collection args."""
+    if not should_collect_django_tasks(config):
+        return None
+    resolved_version = version or installed_django_version()
+    root = project_root or Path(config.rootpath)
+    pythonpath_root = resolve_django_tasks_root(
+        version=resolved_version,
+        project_root=root,
+        download=download,
+    )
+    root_str = str(pythonpath_root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+    add_line = getattr(config, "addinivalue_line", None)
+    if callable(add_line):
+        add_line("pythonpath", root_str)
+    args = getattr(config, "args", None)
+    if isinstance(args, list) and root_str not in args:
+        args.append(root_str)
+    option = getattr(config, "option", None)
+    if option is not None:
+        ignored = list(getattr(option, "ignore", None) or [])
+        for name in IGNORED_TASK_MODULES:
+            ignored.append(str(pythonpath_root / "tasks" / name))
+        option.ignore = ignored
+    return pythonpath_root
+
+
+def pytest_ignore_collect(collection_path: Path, config: Any) -> bool | None:
+    if is_ignored_django_task_module(Path(collection_path)):
+        return True
+    return None
+
+
+def pytest_collection_modifyitems(config: Any, items: list[Any]) -> None:
+    import pytest
+
+    skip = pytest.mark.skip(
+        reason="DummyBackend or ImmediateBackend behaviour excluded for RedisBackend"
+    )
+    for item in items:
+        item_path = getattr(item, "path", None) or getattr(item, "fspath", None)
+        ignored_module = item_path is not None and is_ignored_django_task_module(
+            Path(str(item_path))
+        )
+        if ignored_module or should_skip_django_task_item(item):
+            item.add_marker(skip)
+
+
+def pytest_collection_finish(session: Any) -> None:
+    try:
+        from tasks.test_tasks import TaskTestCase
+    except ImportError:
+        return
+    apply_redis_default_to_tasktestcase(TaskTestCase)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,26 @@
+import os
+
+SECRET_KEY = "django-redis-tasks-tests"
+USE_TZ = True
+INSTALLED_APPS: list[str] = []
+
+TASKS = {
+    "default": {
+        "BACKEND": "redis_tasks.backend.RedisBackend",
+        "QUEUES": ["default", "queue_1", "alternate"],
+    },
+    "immediate": {
+        "BACKEND": "django.tasks.backends.immediate.ImmediateBackend",
+        "QUEUES": [],
+    },
+    "missing": {"BACKEND": "does.not.exist"},
+}
+
+QUEUES = {
+    "default": {
+        "BACKEND": "django_queue.backends.redis.RedisAsyncPriorityQueueJson",
+        "LOCATION": os.environ.get("REDIS_TASKS_TEST_URL", "redis://127.0.0.1:6379/0"),
+        "ENTRY_CLASS": "redis_tasks.entries.TaskQueueEntry",
+        "WORKER": "redis_tasks.worker.RedisTaskWorker",
+    }
+}

--- a/tests/test_django_src.py
+++ b/tests/test_django_src.py
@@ -62,23 +62,6 @@ def test_archive_url_uses_github_tag_for_that_version(version: str):
 
 
 @pytest.mark.parametrize("version", _VERSIONS)
-def test_resolve_uses_django_tests_root_env(tmp_path, monkeypatch, version: str):
-    tests_root = tmp_path / "checkout" / "tests"
-    (tests_root / "tasks").mkdir(parents=True)
-    (tests_root / "tasks" / "test_tasks.py").write_text("# local\n", encoding="utf-8")
-    monkeypatch.setenv("DJANGO_TESTS_ROOT", str(tests_root))
-
-    resolved = resolve_django_tasks_root(
-        version=version,
-        project_root=tmp_path,
-        download=lambda url, dest: pytest.fail("must not download"),
-    )
-
-    assert resolved == tests_root
-    assert (resolved / "tasks" / "test_tasks.py").is_file()
-
-
-@pytest.mark.parametrize("version", _VERSIONS)
 def test_resolve_reuses_existing_version_cache_without_download(tmp_path, version: str):
     cache = tmp_path / cache_dir_name(version)
     (cache / "tasks").mkdir(parents=True)
@@ -135,11 +118,21 @@ def test_extract_tasks_from_archive_only_keeps_tests_tasks(tmp_path, version: st
     }
 
 
-@pytest.mark.parametrize("version", _VERSIONS)
-def test_resolve_fails_with_version_and_expected_path(tmp_path, version: str):
-    def download(url: str, dest: Path) -> None:
-        dest.write_bytes(b"not a tar")
+def _download_invalid_archive(url: str, dest: Path) -> None:
+    dest.write_bytes(b"not a tar")
 
+
+def _download_raises_url_only_error(url: str, dest: Path) -> None:
+    raise DjangoTasksSourceError(f"Could not download Django source from {url}")
+
+
+@pytest.mark.parametrize("version", _VERSIONS)
+@pytest.mark.parametrize(
+    "download",
+    [_download_invalid_archive, _download_raises_url_only_error],
+    ids=["invalid-archive", "download-error"],
+)
+def test_resolve_fails_with_version_and_expected_path(tmp_path, version: str, download):
     expected = tmp_path / cache_dir_name(version) / "tasks" / "test_tasks.py"
     with pytest.raises(DjangoTasksSourceError, match=re.escape(version)) as exc_info:
         resolve_django_tasks_root(

--- a/tests/test_django_src.py
+++ b/tests/test_django_src.py
@@ -1,0 +1,289 @@
+import io
+import re
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tests.django_src import (
+    DjangoTasksSourceError,
+    apply_redis_default_to_tasktestcase,
+    archive_url,
+    cache_dir_name,
+    extract_tasks_from_archive,
+    installed_django_version,
+    is_ignored_django_task_module,
+    pytest_ignore_collect,
+    register_django_tasks_collection,
+    resolve_django_tasks_root,
+    should_collect_django_tasks,
+    should_skip_django_task_item,
+)
+
+# Resolver unit tests pass a version string in; they do not pin the suite to 6.1.
+# Production uses django.get_version() (6.1.0 → "6.1", 6.1.1 → "6.1.1", 6.2 → "6.2").
+_VERSIONS = ("6.1", "6.1.1", "6.2")
+
+
+def _archive_bytes(version: str) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+
+        def add(name: str, content: bytes) -> None:
+            info = tarfile.TarInfo(name=name)
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+
+        add(f"django-{version}/tests/tasks/__init__.py", b"")
+        add(f"django-{version}/tests/tasks/test_tasks.py", b"# django tasks tests\n")
+        add(f"django-{version}/tests/tasks/tasks.py", b"noop = None\n")
+        add(f"django-{version}/tests/runtests.py", b"SHOULD_NOT_EXTRACT\n")
+        add(f"django-{version}/django/__init__.py", b"SHOULD_NOT_EXTRACT\n")
+    return buffer.getvalue()
+
+
+def test_installed_django_version_is_django_get_version():
+    import django
+
+    assert installed_django_version() == django.get_version()
+
+
+@pytest.mark.parametrize("version", _VERSIONS)
+def test_cache_dir_name_matches_gitignore_tool_cache_pattern(version: str):
+    assert cache_dir_name(version) == f".django-src-{version}_cache"
+
+
+@pytest.mark.parametrize("version", _VERSIONS)
+def test_archive_url_uses_github_tag_for_that_version(version: str):
+    assert archive_url(version) == (
+        f"https://github.com/django/django/archive/refs/tags/{version}.tar.gz"
+    )
+
+
+@pytest.mark.parametrize("version", _VERSIONS)
+def test_resolve_uses_django_tests_root_env(tmp_path, monkeypatch, version: str):
+    tests_root = tmp_path / "checkout" / "tests"
+    (tests_root / "tasks").mkdir(parents=True)
+    (tests_root / "tasks" / "test_tasks.py").write_text("# local\n", encoding="utf-8")
+    monkeypatch.setenv("DJANGO_TESTS_ROOT", str(tests_root))
+
+    resolved = resolve_django_tasks_root(
+        version=version,
+        project_root=tmp_path,
+        download=lambda url, dest: pytest.fail("must not download"),
+    )
+
+    assert resolved == tests_root
+    assert (resolved / "tasks" / "test_tasks.py").is_file()
+
+
+@pytest.mark.parametrize("version", _VERSIONS)
+def test_resolve_reuses_existing_version_cache_without_download(tmp_path, version: str):
+    cache = tmp_path / cache_dir_name(version)
+    (cache / "tasks").mkdir(parents=True)
+    (cache / "tasks" / "test_tasks.py").write_text("# cached\n", encoding="utf-8")
+
+    resolved = resolve_django_tasks_root(
+        version=version,
+        project_root=tmp_path,
+        download=lambda url, dest: pytest.fail("must not download"),
+    )
+
+    assert resolved == cache
+    assert (resolved / "tasks" / "test_tasks.py").read_text(encoding="utf-8") == (
+        "# cached\n"
+    )
+
+
+def test_resolve_does_not_use_sibling_version_cache(tmp_path):
+    old = tmp_path / cache_dir_name("6.1")
+    (old / "tasks").mkdir(parents=True)
+    (old / "tasks" / "test_tasks.py").write_text("# old\n", encoding="utf-8")
+    archive = _archive_bytes("6.2")
+
+    def download(url: str, dest: Path) -> None:
+        assert url == archive_url("6.2")
+        dest.write_bytes(archive)
+
+    resolved = resolve_django_tasks_root(
+        version="6.2",
+        project_root=tmp_path,
+        download=download,
+    )
+
+    assert resolved == tmp_path / cache_dir_name("6.2")
+    assert not (resolved / "django").exists()
+    assert not (resolved / "runtests.py").exists()
+    assert (resolved / "tasks" / "test_tasks.py").is_file()
+    assert (old / "tasks" / "test_tasks.py").read_text(encoding="utf-8") == "# old\n"
+
+
+@pytest.mark.parametrize("version", _VERSIONS)
+def test_extract_tasks_from_archive_only_keeps_tests_tasks(tmp_path, version: str):
+    archive_path = tmp_path / "django.tar.gz"
+    archive_path.write_bytes(_archive_bytes(version))
+    dest = tmp_path / "extracted"
+    extract_tasks_from_archive(archive_path, dest)
+    names = {
+        path.relative_to(dest).as_posix() for path in dest.rglob("*") if path.is_file()
+    }
+    assert names == {
+        "tasks/__init__.py",
+        "tasks/test_tasks.py",
+        "tasks/tasks.py",
+    }
+
+
+@pytest.mark.parametrize("version", _VERSIONS)
+def test_resolve_fails_with_version_and_expected_path(tmp_path, version: str):
+    def download(url: str, dest: Path) -> None:
+        dest.write_bytes(b"not a tar")
+
+    expected = tmp_path / cache_dir_name(version) / "tasks" / "test_tasks.py"
+    with pytest.raises(DjangoTasksSourceError, match=re.escape(version)) as exc_info:
+        resolve_django_tasks_root(
+            version=version,
+            project_root=tmp_path,
+            download=download,
+        )
+    assert str(expected) in str(exc_info.value)
+
+
+def test_should_collect_django_tasks_for_ini_testpaths_only():
+    root = Path("/repo").resolve()
+    default_config = SimpleNamespace(
+        rootpath=root,
+        args=["tests"],
+        getini=lambda name: ["tests"] if name == "testpaths" else [],
+    )
+    file_config = SimpleNamespace(
+        rootpath=root,
+        args=["tests/test_redis_backend.py"],
+        getini=lambda name: ["tests"] if name == "testpaths" else [],
+    )
+    assert should_collect_django_tasks(default_config) is True
+    assert should_collect_django_tasks(file_config) is False
+
+
+def test_ignored_django_backend_modules():
+    assert is_ignored_django_task_module(Path("tasks/test_dummy_backend.py"))
+    assert is_ignored_django_task_module(Path("tasks/test_immediate_backend.py"))
+    assert is_ignored_django_task_module(Path("tasks/test_custom_backend.py"))
+    assert not is_ignored_django_task_module(Path("tasks/test_tasks.py"))
+
+
+def test_skip_dummy_and_immediate_tasktestcase_methods():
+    dummy_results = SimpleNamespace(
+        cls=SimpleNamespace(__name__="TaskTestCase", __module__="tasks.test_tasks"),
+        originalname="test_enqueue_task",
+        name="test_enqueue_task",
+    )
+    default_is_dummy = SimpleNamespace(
+        cls=SimpleNamespace(__name__="TaskTestCase", __module__="tasks.test_tasks"),
+        originalname="test_using_correct_backend",
+        name="test_using_correct_backend",
+    )
+    immediate_errors = SimpleNamespace(
+        cls=SimpleNamespace(__name__="TaskTestCase", __module__="tasks.test_tasks"),
+        originalname="test_task_error_invalid_exception",
+        name="test_task_error_invalid_exception",
+    )
+    kept = SimpleNamespace(
+        cls=SimpleNamespace(__name__="TaskTestCase", __module__="tasks.test_tasks"),
+        originalname="test_module_path",
+        name="test_module_path",
+    )
+    assert should_skip_django_task_item(dummy_results)
+    assert should_skip_django_task_item(default_is_dummy)
+    assert should_skip_django_task_item(immediate_errors)
+    assert not should_skip_django_task_item(kept)
+
+
+def test_register_collection_uses_cache_and_skips_download(tmp_path, monkeypatch):
+    import sys
+
+    cache = tmp_path / cache_dir_name("6.1")
+    (cache / "tasks").mkdir(parents=True)
+    (cache / "tasks" / "test_tasks.py").write_text("# cached\n", encoding="utf-8")
+    config = SimpleNamespace(
+        rootpath=tmp_path,
+        args=["tests"],
+        option=SimpleNamespace(ignore=None),
+        getini=lambda name: ["tests"] if name == "testpaths" else [],
+    )
+    monkeypatch.chdir(tmp_path)
+
+    resolved = register_django_tasks_collection(
+        config,
+        version="6.1",
+        project_root=tmp_path,
+        download=lambda url, dest: pytest.fail("must not download"),
+    )
+
+    assert resolved == cache
+    assert str(cache) in sys.path
+    assert str(cache) in config.args
+    assert str(cache / "tasks" / "test_dummy_backend.py") in config.option.ignore
+    assert str(cache / "tasks" / "test_immediate_backend.py") in config.option.ignore
+    assert str(cache / "tasks" / "test_custom_backend.py") in config.option.ignore
+
+
+def test_register_collection_skips_explicit_file_path(tmp_path):
+    config = SimpleNamespace(
+        rootpath=tmp_path,
+        args=["tests/test_redis_backend.py"],
+        getini=lambda name: ["tests"] if name == "testpaths" else [],
+    )
+    resolved = register_django_tasks_collection(
+        config,
+        version="6.1",
+        project_root=tmp_path,
+        download=lambda url, dest: pytest.fail("must not download"),
+    )
+    assert resolved is None
+    assert config.args == ["tests/test_redis_backend.py"]
+
+
+def test_pytest_ignore_collect_drops_dummy_immediate_custom_modules():
+    config = SimpleNamespace()
+    assert pytest_ignore_collect(Path("tasks/test_dummy_backend.py"), config) is True
+    assert (
+        pytest_ignore_collect(Path("tasks/test_immediate_backend.py"), config) is True
+    )
+    assert pytest_ignore_collect(Path("tasks/test_custom_backend.py"), config) is True
+    assert pytest_ignore_collect(Path("tasks/test_tasks.py"), config) is None
+
+
+def test_apply_redis_default_keeps_immediate_and_missing_aliases():
+    cls = SimpleNamespace(
+        _overridden_settings={
+            "TASKS": {
+                "default": {
+                    "BACKEND": "django.tasks.backends.dummy.DummyBackend",
+                    "QUEUES": ["default", "queue_1"],
+                },
+                "immediate": {
+                    "BACKEND": "django.tasks.backends.immediate.ImmediateBackend",
+                    "QUEUES": [],
+                },
+                "missing": {"BACKEND": "does.not.exist"},
+            }
+        }
+    )
+    apply_redis_default_to_tasktestcase(cls)
+    tasks_cfg = cls._overridden_settings["TASKS"]
+    assert tasks_cfg["default"]["BACKEND"] == "redis_tasks.backend.RedisBackend"
+    assert tasks_cfg["default"]["QUEUES"] == ["default", "queue_1"]
+    assert tasks_cfg["immediate"]["BACKEND"].endswith("ImmediateBackend")
+    assert tasks_cfg["missing"]["BACKEND"] == "does.not.exist"
+
+
+def test_django_task_source_is_not_committed():
+    import subprocess
+
+    listed = subprocess.check_output(
+        ["git", "ls-files", ".django-src-*_cache", "**/tasks/test_tasks.py"],
+        text=True,
+    )
+    assert listed.strip() == ""

--- a/tests/test_redis_backend.py
+++ b/tests/test_redis_backend.py
@@ -138,6 +138,12 @@ class TestEnqueue:
         assert result.status == TaskResultStatus.READY
         uuid.UUID(result.id)
 
+    def test_clear_removes_enqueued_entries(self, redis_backend):
+        result = redis_backend.enqueue(make_task(), (1, 2), {})
+        redis_backend.clear()
+        with pytest.raises(TaskResultDoesNotExist):
+            redis_backend.get_result(result.id)
+
     def test_enqueue_accepts_async_task(self, redis_backend):
         task = make_task(func=async_add)
         result = redis_backend.enqueue(task, (1, 2), {})
@@ -360,6 +366,13 @@ class TestGetResult:
         result = redis_backend.get_result(str(entry_id))
         assert result.status == TaskResultStatus.SUCCESSFUL
         assert result.return_value == 3
+
+    @pytest.mark.asyncio
+    async def test_get_result_from_async_test(self, redis_backend, task_queue):
+        result = await redis_backend.aenqueue(make_task(), (1, 2), {})
+        fetched = redis_backend.get_result(result.id)
+        assert fetched.id == result.id
+        assert fetched.status == TaskResultStatus.READY
 
     def test_get_result_reconstructs_decorated_task(self, redis_backend, task_queue):
         entry_id = task_queue.enqueue(

--- a/tests/test_suite_settings.py
+++ b/tests/test_suite_settings.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+from django.tasks import task_backends
+from django.test import SimpleTestCase
+
+from redis_tasks.backend import RedisBackend
+
+
+class TestSuiteDjangoSettings(SimpleTestCase):
+    def test_default_task_backend_setting_is_redis(self):
+        self.assertEqual(
+            settings.TASKS["default"]["BACKEND"],
+            "redis_tasks.backend.RedisBackend",
+        )
+
+
+def test_default_task_backend_is_redis_instance(redis_url):
+    assert isinstance(task_backends["default"], RedisBackend)

--- a/uv.lock
+++ b/uv.lock
@@ -168,6 +168,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-django" },
     { name = "pytest-mock" },
     { name = "ruff" },
     { name = "testcontainers" },
@@ -184,6 +185,7 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", specifier = ">=0.25.0" },
+    { name = "pytest-django", specifier = ">=4.14.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "ruff", specifier = ">=0.15.14" },
     { name = "testcontainers", specifier = ">=4.9.0" },
@@ -275,6 +277,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-django"
+version = "4.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/f6/3851312120c2bf2f19cafff931e75059aad1ba670703cd751e2fde9bc942/pytest_django-4.14.0.tar.gz", hash = "sha256:26787dd3f422cfbab8f55b80a776e2edea7a11092cb74e960bef1312515708ef", size = 94700, upload-time = "2026-08-10T14:13:08.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/03/850bffad2b581c440ca51c039d74504d5a422c94bda0bdb8a8ba5068d48b/pytest_django-4.14.0-py3-none-any.whl", hash = "sha256:c533b08d89cc675efcd5398eea270b34547e35f9a3608e2c9748dd88428ea187", size = 27067, upload-time = "2026-08-10T14:13:06.998Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Overview

Proves this Redis backend against Django's own applicable `django.tasks` contract for the installed Django version, in the default pytest run. Usage now points at Django's task documentation.

## Changes

- Collects Django's `tests/tasks` tree for `django.get_version()` from a gitignored `.django-src-<version>_cache/` (GitHub tag archive on first miss, reused afterwards).
- Runs those cases as Django tests against `RedisBackend` and the suite Redis instance, not Dummy or Immediate as the default backend.
- Omits Dummy, Immediate, and custom-backend modules, and skips Dummy `.results` / Immediate SUCCESSFUL-on-enqueue methods rather than rewriting them.
- Adds `RedisBackend.clear()` so Django's per-test reset can empty queue records.
- Links the Usage section to Django's `django.tasks` docs.

## Impact

Default pytest now fails if this backend drifts from Django's task API. First run for a Django version may fetch the tag archive; later runs for that version stay local. Offline with no cache fails collection with the version and expected path. ruff does not walk the cache.

## Notes

Dummy and Immediate backend modules remain excluded. Cron and recurring schedules are not part of this change.

Made with [Cursor](https://cursor.com)